### PR TITLE
Use linalg for frgb

### DIFF
--- a/Lux/src/frgb.cpp
+++ b/Lux/src/frgb.cpp
@@ -1,126 +1,64 @@
 #include "frgb.hpp"
 #include "gamma_lut.hpp"
 
-#define R 0
-#define G 1
-#define B 2
+//using namespace linalg;
 
 static gamma_LUT glut( 2.2f );
 
-frgb::frgb()                              { c[ R ] = 0.0;     c[ G ] = 0.0;   c[ B ] = 0.0; }
-frgb::frgb( float r, float g, float b )   { c[ R ] = r;       c[ G ] = g;     c[ B ]= b;    }
-// TODO - add constructor from bracketed list
-
-// construct from 24 bit color
-frgb::frgb( unsigned char r, unsigned char g, unsigned char b ) { 
-    c[ R ] = glut.SRGB_to_linear( r );
-    c[ G ] = glut.SRGB_to_linear( g );
-    c[ B ] = glut.SRGB_to_linear( b );
-};
-
-// frgb( unsigned int in ) { bit shifty stuff}    
-
-// destructor
-frgb::~frgb() {}
-
-// iterators 
-
-// accessors
-// question - how to overload [] operator for assignment?
-float& frgb::operator []( int i ) { return c[ i ]; }
-
-inline float frgb::r()       { return c[ R ]; }
-inline float frgb::g()       { return c[ G ]; }
-inline float frgb::b()       { return c[ B ]; }
+inline float r( const frgb &c )       { return c.R; }
+inline float g( const frgb &c )       { return c.G; }
+inline float b( const frgb &c )       { return c.B; }
 
 // returns single bytes per component - assumes [0.0, 1.0] range
 // clip or constrain out of range values before using
-inline unsigned char frgb::rc() {  return (unsigned char)glut.linear_to_SRGB( c[ R ] ); }
-inline unsigned char frgb::gc() {  return (unsigned char)glut.linear_to_SRGB( c[ G ] ); }
-inline unsigned char frgb::bc() {  return (unsigned char)glut.linear_to_SRGB( c[ B ] ); }
+inline unsigned char rc( const frgb &c ) {  return (unsigned char)glut.linear_to_SRGB( c.R ); }
+inline unsigned char gc( const frgb &c ) {  return (unsigned char)glut.linear_to_SRGB( c.G ); }
+inline unsigned char bc( const frgb &c ) {  return (unsigned char)glut.linear_to_SRGB( c.B ); }
 
 // inline unsigned int ul() {} // bit shifty stuff
 
 // set component
-inline void frgb::setr( float r )   { c[ R ] = r; }
-inline void frgb::setg( float g )   { c[ G ] = g; }
-inline void frgb::setb( float b )   { c[ B ] = b; }
-inline void frgb::set( float r, float g, float b) { c[ R ] = r;  c[ G ] = g;  c[ B ] = b; }
+inline void setr( frgb &c, const float& r )   { c.R = r; }
+inline void setg( frgb &c, const float& g )   { c.G = g; }
+inline void setb( frgb &c, const float& b )   { c.B = b; }
+void set(  frgb &c, const float& r, const float& g, const float& b) { c.R = r;  c.G = g;  c.B = b; }
+frgb set(  const float& r, const float& g, const float& b ) { return { r, g, b }; }
+
 // TODO - set from bracketed list
 
-inline void frgb::setrc( unsigned char r ) { c[ R ] = glut.SRGB_to_linear( r ); }
-inline void frgb::setgc( unsigned char g ) { c[ G ] = glut.SRGB_to_linear( g ); }
-inline void frgb::setbc( unsigned char b ) { c[ B ] = glut.SRGB_to_linear( b ); }
-inline void frgb::setc( unsigned char r, unsigned char g, unsigned char b ) { setrc( r );   setgc( g );   setbc( b ); }
+inline void setrc( frgb &c, const unsigned char& r ) { c.R = glut.SRGB_to_linear( r ); }
+inline void setgc( frgb &c, const unsigned char& g ) { c.G = glut.SRGB_to_linear( g ); }
+inline void setbc( frgb &c, const unsigned char& b ) { c.B = glut.SRGB_to_linear( b ); }
+void setc(  frgb &c, const unsigned char& r, const unsigned char& g, const unsigned char& b ) 
+{ setrc( c, r );   setgc( c, g );   setbc( c, b ); }
+frgb setc( const unsigned char& r, const unsigned char& g, const unsigned char& b )
+{ return { glut.SRGB_to_linear( r ), glut.SRGB_to_linear( g ), glut.SRGB_to_linear( b ) }; }
 
-//inline void frgb::setul( unsigned int in ) {} // bit shifty stuff
-
-// arithmetic operators
-const frgb& frgb::operator += ( frgb rhs ) { c[R] += rhs.c[R];  c[G] += rhs.c[G];  c[B] += rhs.c[B];  return *this; }
-const frgb& frgb::operator -= ( frgb rhs ) { c[R] -= rhs.c[R];  c[G] -= rhs.c[G];  c[B] -= rhs.c[B];  return *this; }
-const frgb& frgb::operator *= ( frgb rhs ) { c[R] *= rhs.c[R];  c[G] *= rhs.c[G];  c[B] *= rhs.c[B];  return *this; }
-
-const frgb& frgb::operator *= ( float rhs ) { c[R] *= rhs;  c[G] *= rhs;  c[B] *= rhs;  return *this; }
-const frgb& frgb::operator /= ( float rhs ) { c[R] /= rhs;  c[G] /= rhs;  c[B] /= rhs;  return *this; }
-
-
-frgb frgb::operator + ( frgb rhs ) { 
-    frgb out;  
-    out.set( c[R] + rhs.c[R],  c[G] + rhs.c[G],  c[B] + rhs.c[B] ); 
-    return out; 
-}
-
-frgb frgb::operator - ( frgb rhs ) { 
-    frgb out;  
-    out.set( c[R] - rhs.c[R],  c[G] - rhs.c[G],  c[B] - rhs.c[B] ); 
-    return out; 
-}
-
-frgb frgb::operator * ( frgb rhs ) { 
-    frgb out;  
-    out.set( c[R] * rhs.c[R],  c[G] * rhs.c[G],  c[B] * rhs.c[B] ); 
-    return out; 
-}
-
-frgb frgb::operator * ( float rhs ) { 
-    frgb out;  
-    out.set( c[R] * rhs,  c[G] * rhs,  c[B] * rhs ); 
-    return out; 
-}
-
-frgb frgb::operator / ( float rhs ) { 
-    frgb out;  
-    out.set( c[R] / rhs,  c[G] / rhs,  c[B] / rhs ); 
-    return out; 
-}
-
-// color clipping
-void frgb::clamp( float minc, float maxc ) {
-    c[ R ] = std::clamp( c[ R ], minc, maxc );
-    c[ G ] = std::clamp( c[ G ], minc, maxc );
-    c[ B ] = std::clamp( c[ B ], minc, maxc );
-}
+//inline void setul( unsigned int in ) {} // bit shifty stuff
 
 // Clip to range [ 0.0, 1.0 ] but keep colors in proportion
-void frgb::constrain() {
+frgb& constrain( const frgb &c ) {
+    frgb out = c;
     // find maximum color
-    float max = *std::max_element( c.begin(), c.end() );
+    float max = linalg::maxelem( c );
     if( max > 1.0f ) {
         // bring negative colors to zero
-        clamp( 0.0f, max );
+        linalg::clamp( out, 0.0f, max );
         // if max color > 1.0 divide all colors by max
-        *this /= max;
+        out /= max;
     }
+    return out;
 }
 
-std::ostream & operator << ( std::ostream &out, const frgb& f ) { 
-        out << "Linear - R: " << f.c[ 0 ] << " G: " << f.c[ 1 ] << " B: " << f.c[ 2 ] << "\n";
+/* std::ostream & operator << ( std::ostream &out, const frgb& c ) { 
+        out << "Linear - R: " << c.R << " G: " << c.G << " B: " << c.B << "\n";
         return out;
 }
+*/
 
-void frgb::print_SRGB() {
-    int r = ( int )rc();
-    int g = ( int )gc();
-    int b = ( int )bc();
+void print_SRGB( const frgb &c ) {
+    int r = ( int )rc( c );
+    int g = ( int )gc( c );
+    int b = ( int )bc( c );
     std::cout << "SRGB   - R: " << r << " G: " << g << " B: " << b;
 }

--- a/Lux/src/frgb.hpp
+++ b/Lux/src/frgb.hpp
@@ -2,90 +2,53 @@
 #define __FRGB_HPP
 
 #include <iostream>
-#include <array>
-#include <algorithm>
+//#include <array>
+//#include <algorithm>
+#include "linalg.h"
 
-class frgb {
-private:
-    std::array< float, 3 > c;
+#ifndef R
+    #define R x 
+#endif // R
+#ifndef G
+    #define G y
+#endif // G
+#ifndef B
+    #define B z
+#endif // B
 
-public:
-    // constructors
-    frgb();
-    frgb( float r, float g, float b );
-    // TODO - add constructor from bracketed list
+typedef linalg::vec< float,3 > frgb;
 
-    // construct from 24 bit color
-    frgb( unsigned char r, unsigned char g, unsigned char b );
-    
-    // might be more efficient to do conversion in image class as lookup table can be class member 
-    // and conversion to a large block of frgb can use std::move
-    // frgb( unsigned char r, unsigned char g, unsigned char b, std::unique_ptr<gamma_lut> t ); 
-    // frgb( unsigned int in ) { bit shifty stuff}    
-    // frgb( unsigned int in, std::unique_ptr<gamma_lut> t ) { bit shifty stuff }
+inline float r( const frgb &c );
+inline float g( const frgb &c );
+inline float b( const frgb &c );
 
-    // destructor
-    ~frgb();
+// returns single bytes per component - assumes [0.0, 1.0] range
+// clip or constrain out of range values before using
+inline unsigned char rc( const frgb &c );
+inline unsigned char gc( const frgb &c );
+inline unsigned char bc( const frgb &c );
 
-    // iterators 
-    std::array< float, 3>::iterator begin() { return c.begin(); }
-    std::array< float, 3>::const_iterator begin() const { return c.begin(); }
-    std::array< float, 3>::iterator end() { return c.end(); }
-    std::array< float, 3>::const_iterator end() const { return c.end(); }
-    
-    // accessors
-    float& operator [] ( int i );
-    const float& operator [] (int i) const { return c[ i ]; }
+// inline unsigned int ul( const frgb &c ) {} // bit shifty stuff
 
-    inline float r();
-    inline float g();
-    inline float b();
+// set component
+inline void setr( frgb &c, const float& r );
+inline void setg( frgb &c, const float& g );
+inline void setb( frgb &c, const float& b );
+void set(  frgb &c, const float& r, const float& g, const float& b );
+frgb set(  const float& r, const float& g, const float& b );
+// TODO - set from bracketed list
 
-    // returns single bytes per component - assumes [0.0, 1.0] range
-    // clip or constrain out of range values before using
-    inline unsigned char rc();
-    inline unsigned char gc();
-    inline unsigned char bc();
-    
+inline void setrc( frgb &c, const unsigned char& r );
+inline void setgc( frgb &c, const unsigned char& g );
+inline void setbc( frgb &c, const unsigned char& b );
+void setc(  frgb &c, const unsigned char& r, const unsigned char& g, const unsigned char& b );
+frgb setc(  const unsigned char& r, const unsigned char& g, const unsigned char& b );
 
-    // inline unsigned int ul() {} // bit shifty stuff
+// I/O operators
+//std::ostream &operator << ( std::ostream &out, const frgb& f );
+void print_SRGB( const frgb &c );
 
-    // set component
-    inline void setr( float r );
-    inline void setg( float g );
-    inline void setb( float b );
-    inline void set( float r, float g, float b);
-    // TODO - set from bracketed list
+frgb& constrain( const frgb &c );   // Clip to range [ 0.0, 1.0 ] but keep colors in proportion
 
-    inline void setrc( unsigned char r );
-    inline void setgc( unsigned char g );
-    inline void setbc( unsigned char b );
-    inline void setc( unsigned char r, unsigned char g, unsigned char b );
-
-    //inline void setul( unsigned int in );
-    
-    // arithmetic operators
-    const frgb& operator += ( frgb rhs );
-    const frgb& operator -= ( frgb rhs );
-    const frgb& operator *= ( frgb rhs );
-
-    const frgb& operator *= ( float rhs );
-    const frgb& operator /= ( float rhs );
-
-    frgb operator + ( frgb rhs );
-    frgb operator - ( frgb rhs );
-    frgb operator * ( frgb rhs );
-
-    frgb operator * ( float rhs );
-    frgb operator / ( float rhs);
-
-    // I/O operators
-    friend std::ostream &operator << ( std::ostream &out, const frgb& f );
-
-    void print_SRGB();
-
-    void clamp( float minc, float maxc );   // clamp components to specified range
-    void constrain();   // Clip to range [ 0.0, 1.0 ] but keep colors in proportion
-};
 
 #endif // __FRGB_HPP

--- a/Lux/src/gamma_lut.cpp
+++ b/Lux/src/gamma_lut.cpp
@@ -67,11 +67,12 @@ float gamma_LUT::SRGB_to_linear(unsigned char index) { return SRGB_to_linear_LUT
 
 // may be more efficient to do reinterpret_cast on array of pointers to float
 unsigned char gamma_LUT::linear_to_SRGB( float index ) {
-  // Cases for table underflow (SRGB value less than two)
+  // Cases for table underflow (SRGB value less than two) and overflow
   if( index < 0.000032f ) {
-    if( index == 0.0f ) return 0;
+    if( index <= 0.0f ) return 0x00;
     else return 1;
   }
+  if( index >= 1.0 ) return 0xff;
 
   flubber flub;
   flub.f = index;

--- a/Lux/src/lux.cpp
+++ b/Lux/src/lux.cpp
@@ -5,18 +5,21 @@
 
 void test_frgb() {
     using std::cout;
+    using namespace linalg;
+    using namespace ostream_overloads;
+
     cout << "TESTING FRGB\n\n";
     frgb color( -1.5f, 0.5f, 2.5f );
     cout << "Initial color     " << color << "\n\n";
-    color.clamp( -1.0f, 2.0f );
+    color = clamp( color, -1.0f, 2.0f );
     cout << "Clamped color     " << color << "\n\n";
-    color.constrain();
+    color = constrain( color );
     cout << "Constrained color " << color << "\n\n";
-    color.print_SRGB();
+    print_SRGB( color );
 
-    frgb ucolor( (unsigned char)0x00, (unsigned char)0x80, (unsigned char)0xff );
+    frgb ucolor = setc( (unsigned char)0x00, (unsigned char)0x80, (unsigned char)0xff );
     cout << "\n\nColor from unsigned char " << ucolor << "\n\n";
-    ucolor.print_SRGB();
+    print_SRGB( ucolor );
     cout << "\n\n";
 
     ucolor += color;
@@ -29,9 +32,6 @@ void test_frgb() {
     cout << "Color after color[ 0 ] = 0.5 " << color << "\n\n";
 
     float a = color[ 0 ];
-
-    auto it = color.begin();
-    it = color.end();
 }
 
 


### PR DESCRIPTION
frgb.hpp and .cpp:
  Replace `class frgb` with `typedef linalg::vec< float,3 > frgb`
  Change member functions to stand-alones
  Use linalg functionality for operators and `clamp()`
  
gamma_LUT.cpp:
  Refine gamma_LUT edge cases

lux.cpp:
  Modify test case syntax for new frgb
