### PR TITLE
Add uimage

### DIFF
--- a/Lux/CMakeLists.txt
+++ b/Lux/CMakeLists.txt
@@ -23,6 +23,10 @@ src/fimage.hpp
 src/fimage.cpp
 src/image_loader.hpp
 src/image_loader.cpp
+src/ucolor.hpp
+src/ucolor.cpp
+src/uimage.hpp
+src/uimage.cpp
 src/linalg.h
 )
 

--- a/Lux/src/fimage.cpp
+++ b/Lux/src/fimage.cpp
@@ -6,7 +6,7 @@
 
 // pixel modification functions
 void fimage :: grayscale() {
-    std :: transform( base.begin(), base.end(), base.begin(),  []( frgb &f ) { return gray( f ); } );
+    std :: transform( base.begin(), base.end(), base.begin(), []( frgb &f ) { return gray( f ); } );
 }
 
 void fimage :: load( const std :: string& filename ) {
@@ -65,5 +65,8 @@ void fimage :: write_jpg( const std :: string& filename, int quality ) {
 	wrapped_write_jpg( filename.c_str(), dim.x, dim.y, 3, img.data(), quality );
 }
 
-void fimage :: write_png( const std :: string& filename ) {
+void fimage :: write_png( const std :: string& filename ) {    
+    std :: vector< unsigned char > img;
+	quantize( img );
+	wrapped_write_png( filename.c_str(), dim.x, dim.y, 3, img.data() );
 }

--- a/Lux/src/fimage.hpp
+++ b/Lux/src/fimage.hpp
@@ -1,9 +1,14 @@
+// Floating point image class using image template as a base
+
+#ifndef __FIMAGE_HPP
+#define __FIMAGE_HPP
+
 #include "image.hpp"
 
 class fimage : public image< frgb > {
 
 protected:
-    void quantize( std::vector< unsigned char >& img );
+    void quantize( std :: vector< unsigned char >& img );
 
 public:
     fimage() : image() {}     
@@ -16,7 +21,9 @@ public:
     void grayscale();
 
     // I/O functions
-    void load(      const std::string& filename );
-    void write_jpg( const std::string& filename, int quality );
-    void write_png( const std::string& filename );
+    void load(      const std :: string& filename );
+    void write_jpg( const std :: string& filename, int quality );
+    void write_png( const std :: string& filename );
 };
+
+#endif // __FIMAGE_HPP

--- a/Lux/src/image.cpp
+++ b/Lux/src/image.cpp
@@ -48,7 +48,7 @@ template< class T > bb2f I :: get_bounds() { return bounds; }
 template< class T > void I :: set_bounds( const bounding_box< float, 2 >& bb ) { bounds = bb; }
 
 // returns true if images have same dimensions
-template< class T > bool I :: compare_dims( const I& img ) { return ( dim == img.dim ); } 
+// template< class T, class U > bool I :: compare_dims( const image< U >& img ) { return ( dim == img.dim ); } 
 
 template< class T > void I :: fill( const T& c ) {
     std :: fill( base.begin(), base.end(), c );
@@ -124,5 +124,6 @@ template< class T > I& I :: operator /= ( const float& rhs ) {
     return *this;
 }
 
-template class image< frgb >;
-template class image< vec2f >;
+template class image< frgb >;       // fimage
+template class image< ucolor >;     // uimage
+template class image< vec2f >;      // vector_field

--- a/Lux/src/image.hpp
+++ b/Lux/src/image.hpp
@@ -7,6 +7,7 @@
 
 #include "vect2.hpp"
 #include "frgb.hpp"
+#include "ucolor.hpp"
 #include <vector>
 
 enum image_extend
@@ -66,7 +67,7 @@ public:
     void set_dim( const vec2i& dims );
     bb2f get_bounds();
     void set_bounds( const bb2f& bb );
-    bool compare_dims( const I& img ); // returns true if images have same dimensions
+    template< class U > bool compare_dims( const image< U >& img ) { return ( dim == img.dim ); }  // returns true if images have same dimensions
 
     // Sample base image
     T index( const vec2i& vi, const image_extend& extend = SAMP_SINGLE );

--- a/Lux/src/image.hpp
+++ b/Lux/src/image.hpp
@@ -9,6 +9,7 @@
 #include "frgb.hpp"
 #include "ucolor.hpp"
 #include <vector>
+#include <memory>
 
 enum image_extend
 {
@@ -82,10 +83,9 @@ public:
     // size modification functions
     void resize( vec2i siz );
     void crop( const bb2i& bb );
-    void circle_crop( float ramp_width = 0.0f );	// Colors black everything outside of a centered circle
+    void circle_crop( float ramp_width = 0.0f );	// Sets to zero everything outside of a centered circle
 
     // pixel modification functions
-    //void grayscale();
     void fill( const T& c );
 
     // masking

--- a/Lux/src/image_loader.cpp
+++ b/Lux/src/image_loader.cpp
@@ -19,7 +19,13 @@ image_loader :: ~image_loader() {
 }
 
 void wrapped_write_jpg( const std::string& filename, const int xdim, const int ydim, const int channels, const unsigned char* data, const int quality ) {
-	int ok = stbi_write_jpg( filename.c_str(), xdim, ydim, 3, data, quality );
+	int ok = stbi_write_jpg( filename.c_str(), xdim, ydim, channels, data, quality );
+    if( !ok ) 
+        throw std::runtime_error (std::string( "Write jpeg error: \nFile" ) + filename + "\nReason:" + stbi_failure_reason() + "\n" ); 
+}
+
+void wrapped_write_png( const std::string& filename, const int xdim, const int ydim, const int channels, const unsigned char* data ) {
+	int ok = stbi_write_png( filename.c_str(), xdim, ydim, channels, data, xdim * channels );
     if( !ok ) 
         throw std::runtime_error (std::string( "Write jpeg error: \nFile" ) + filename + "\nReason:" + stbi_failure_reason() + "\n" ); 
 }

--- a/Lux/src/image_loader.cpp
+++ b/Lux/src/image_loader.cpp
@@ -7,6 +7,7 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "../../stb_image/stb_image_write.h"
 #include "image_loader.hpp"
+#include <stdexcept>
 
 image_loader :: image_loader( const std::string& filename ) : stbi_ptr( stbi_load( filename.c_str(), &xsiz, &ysiz, &channels, 0 ) ) {
     if(!stbi_ptr) 

--- a/Lux/src/image_loader.hpp
+++ b/Lux/src/image_loader.hpp
@@ -20,3 +20,5 @@ public:
 };
 
 void wrapped_write_jpg( const std :: string& filename, const int xdim, const int ydim, const int channels, const unsigned char* data, const int quality );
+
+void wrapped_write_png( const std :: string& filename, const int xdim, const int ydim, const int channels, const unsigned char* data );

--- a/Lux/src/joy_rand.hpp
+++ b/Lux/src/joy_rand.hpp
@@ -8,10 +8,11 @@
 static std::random_device rd;   // non-deterministic generator
 static std::mt19937 gen( rd() ); // start random engine
 static std::uniform_real_distribution<float> rand1( 0.0f, 1.0f );
+static std::uniform_int_distribution<unsigned int> rand_bit( 0, 1 );
 static float rand_range( const float a, const float b ) { return a + ( b - a ) * rand1(gen); }
 
 // remainder function
-static float remf( const float f ) { return f - floorf( f ); }
+static float remf( const float f ) { return f - floor( f ); }
 
 // "true" modulo operator
 static float tmodf( const float f, const float m ) { return remf( f / m ) * m; }
@@ -19,7 +20,7 @@ static float tmodf( const float f, const float m ) { return remf( f / m ) * m; }
 // Modulo operator that reflects in odd-numbered segments
 static float rmodf( const float f, const float m ) { 
     float rat = f / m;
-    int irat = floorf( rat );
+    int irat = floor( rat );
     if( irat % 2 ) return ( 1.0 - remf( rat ) ) * m;
     else return remf( rat ) * m;
 }

--- a/Lux/src/linalg.h
+++ b/Lux/src/linalg.h
@@ -45,7 +45,6 @@
 
 // *****************************************
 // Modifications - Joy Hughes May 17, 2022
-// change math functions from double precision to floating point
 // Factory functions for 2D matrices
 // #include "joy_rand.hpp" and apply rand_range()
 
@@ -189,23 +188,23 @@ namespace linalg
         struct op_or  { template<class A, class B> constexpr auto operator() (A a, B b) const -> decltype(a || b) { return a || b; } };
 
         // Function objects for applying standard library math functions
-        struct std_abs      { template<class A> auto operator() (A a) const -> decltype(std::abs  (a)) { return std::fabs   (a); } };
-        struct std_floor    { template<class A> auto operator() (A a) const -> decltype(std::floor(a)) { return std::floorf(a); } };
-        struct std_ceil     { template<class A> auto operator() (A a) const -> decltype(std::ceil (a)) { return std::ceilf (a); } };
-        struct std_exp      { template<class A> auto operator() (A a) const -> decltype(std::exp  (a)) { return std::expf  (a); } };
-        struct std_log      { template<class A> auto operator() (A a) const -> decltype(std::log  (a)) { return std::logf  (a); } };
-        struct std_log10    { template<class A> auto operator() (A a) const -> decltype(std::log10(a)) { return std::log10f(a); } };
-        struct std_sqrt     { template<class A> auto operator() (A a) const -> decltype(std::sqrt (a)) { return std::sqrtf (a); } };
-        struct std_sin      { template<class A> auto operator() (A a) const -> decltype(std::sin  (a)) { return std::sinf  (a); } };
-        struct std_cos      { template<class A> auto operator() (A a) const -> decltype(std::cos  (a)) { return std::cosf  (a); } };
-        struct std_tan      { template<class A> auto operator() (A a) const -> decltype(std::tan  (a)) { return std::tanf  (a); } };
-        struct std_asin     { template<class A> auto operator() (A a) const -> decltype(std::asin (a)) { return std::asinf (a); } };
-        struct std_acos     { template<class A> auto operator() (A a) const -> decltype(std::acos (a)) { return std::acosf (a); } };
-        struct std_atan     { template<class A> auto operator() (A a) const -> decltype(std::atan (a)) { return std::atanf (a); } };
-        struct std_sinh     { template<class A> auto operator() (A a) const -> decltype(std::sinh (a)) { return std::sinhf (a); } };
-        struct std_cosh     { template<class A> auto operator() (A a) const -> decltype(std::cosh (a)) { return std::coshf (a); } };
-        struct std_tanh     { template<class A> auto operator() (A a) const -> decltype(std::tanh (a)) { return std::tanhf (a); } };
-        struct std_round    { template<class A> auto operator() (A a) const -> decltype(std::round(a)) { return std::roundf(a); } };
+        struct std_abs      { template<class A> auto operator() (A a) const -> decltype(std::abs  (a)) { return std::abs  (a); } };
+        struct std_floor    { template<class A> auto operator() (A a) const -> decltype(std::floor(a)) { return std::floor(a); } };
+        struct std_ceil     { template<class A> auto operator() (A a) const -> decltype(std::ceil (a)) { return std::ceil (a); } };
+        struct std_exp      { template<class A> auto operator() (A a) const -> decltype(std::exp  (a)) { return std::exp  (a); } };
+        struct std_log      { template<class A> auto operator() (A a) const -> decltype(std::log  (a)) { return std::log  (a); } };
+        struct std_log10    { template<class A> auto operator() (A a) const -> decltype(std::log10(a)) { return std::log10(a); } };
+        struct std_sqrt     { template<class A> auto operator() (A a) const -> decltype(std::sqrt (a)) { return std::sqrt (a); } };
+        struct std_sin      { template<class A> auto operator() (A a) const -> decltype(std::sin  (a)) { return std::sin  (a); } };
+        struct std_cos      { template<class A> auto operator() (A a) const -> decltype(std::cos  (a)) { return std::cos  (a); } };
+        struct std_tan      { template<class A> auto operator() (A a) const -> decltype(std::tan  (a)) { return std::tan  (a); } };
+        struct std_asin     { template<class A> auto operator() (A a) const -> decltype(std::asin (a)) { return std::asin (a); } };
+        struct std_acos     { template<class A> auto operator() (A a) const -> decltype(std::acos (a)) { return std::acos (a); } };
+        struct std_atan     { template<class A> auto operator() (A a) const -> decltype(std::atan (a)) { return std::atan (a); } };
+        struct std_sinh     { template<class A> auto operator() (A a) const -> decltype(std::sinh (a)) { return std::sinh (a); } };
+        struct std_cosh     { template<class A> auto operator() (A a) const -> decltype(std::cosh (a)) { return std::cosh (a); } };
+        struct std_tanh     { template<class A> auto operator() (A a) const -> decltype(std::tanh (a)) { return std::tanh (a); } };
+        struct std_round    { template<class A> auto operator() (A a) const -> decltype(std::round(a)) { return std::round(a); } };
         struct std_fmod     { template<class A, class B> auto operator() (A a, B b) const -> decltype(std::fmod    (a, b)) { return std::fmodf    (a, b); } };
         struct std_pow      { template<class A, class B> auto operator() (A a, B b) const -> decltype(std::pow     (a, b)) { return std::powf     (a, b); } };
         struct std_atan2    { template<class A, class B> auto operator() (A a, B b) const -> decltype(std::atan2   (a, b)) { return std::atan2f   (a, b); } };

--- a/Lux/src/linalg.h
+++ b/Lux/src/linalg.h
@@ -205,10 +205,10 @@ namespace linalg
         struct std_cosh     { template<class A> auto operator() (A a) const -> decltype(std::cosh (a)) { return std::cosh (a); } };
         struct std_tanh     { template<class A> auto operator() (A a) const -> decltype(std::tanh (a)) { return std::tanh (a); } };
         struct std_round    { template<class A> auto operator() (A a) const -> decltype(std::round(a)) { return std::round(a); } };
-        struct std_fmod     { template<class A, class B> auto operator() (A a, B b) const -> decltype(std::fmod    (a, b)) { return std::fmodf    (a, b); } };
-        struct std_pow      { template<class A, class B> auto operator() (A a, B b) const -> decltype(std::pow     (a, b)) { return std::powf     (a, b); } };
-        struct std_atan2    { template<class A, class B> auto operator() (A a, B b) const -> decltype(std::atan2   (a, b)) { return std::atan2f   (a, b); } };
-        struct std_copysign { template<class A, class B> auto operator() (A a, B b) const -> decltype(std::copysign(a, b)) { return std::copysignf(a, b); } };
+        struct std_fmod     { template<class A, class B> auto operator() (A a, B b) const -> decltype(std::fmod    (a, b)) { return std::fmod    (a, b); } };
+        struct std_pow      { template<class A, class B> auto operator() (A a, B b) const -> decltype(std::pow     (a, b)) { return std::pow     (a, b); } };
+        struct std_atan2    { template<class A, class B> auto operator() (A a, B b) const -> decltype(std::atan2   (a, b)) { return std::atan2   (a, b); } };
+        struct std_copysign { template<class A, class B> auto operator() (A a, B b) const -> decltype(std::copysign(a, b)) { return std::copysign(a, b); } };
 
         // Function objects for applying random range function and modified modulos added by Joy Hughes
         struct joy_rbox     { template<class A, class B> auto operator() (A a, B b) const -> decltype(rand_range(a, b)) { return rand_range(a, b); } };

--- a/Lux/src/lux.cpp
+++ b/Lux/src/lux.cpp
@@ -3,6 +3,9 @@
 #include "vect2.hpp"
 #include "frgb.hpp"
 #include "fimage.hpp"
+#include "ucolor.hpp"
+#include "uimage.hpp"
+
 
 #include <unistd.h>
 
@@ -56,7 +59,7 @@ void test_vect2() {
     using namespace linalg;
     using namespace ostream_overloads;
 
-    cout << "TESTING VECT2\n\n";
+    cout << "\nTESTING VECT2\n\n";
 
     vec2f a = { 1.0f, 2.0f };
     cout << "vector a " << a << "\n";
@@ -104,9 +107,9 @@ void test_vect2() {
 
 }
 
-void test_image() {
+void test_fimage() {
     using std::cout;
-    cout << "TESTING IMAGE\n\n";
+    cout << "\nTESTING FIMAGE\n\n";
 
     fimage a;
     a.load( "../../Jen-C/hk_square.jpg" ); 
@@ -129,10 +132,45 @@ void test_image() {
 
 }
 
+void  test_ucolor() {
+    using std::cout;
+
+    cout << "\nTESTING UCOLOR\n\n";
+    ucolor a = 0xff4080ff;
+    cout << std::hex << (int)rc( a ) << " " << (int)gc( a ) << " " << (int)bc( a ) << "\n\n";
+}
+
+void test_uimage() {
+    using std::cout;
+    cout << "\nTESTING UIMAGE\n\n";
+
+    uimage a;
+    a.load( "../../Jen-C/hk_square.jpg" ); 
+    a.write_jpg( " hk_utry.jpg", 100 );
+
+    uimage b( a );
+    cout << "image size comparison " << b.compare_dims( a ) << "\n";
+
+    b.grayscale();
+    b.write_jpg( " hk_ugray.jpg", 100 );
+/*
+    b *= { 0.3f, 0.6f, 1.0f };
+    b.write_jpg( " hk_tint.jpg", 100 );
+
+    b *= 1.5f;
+    b.write_jpg( " hk_bright.jpg", 100 );
+
+    b -= a;
+    b.write_jpg( " hk_diff.jpg", 100 );
+*/
+}
+
 int main() {
     test_frgb();
     test_vect2();
-    test_image();
+    test_fimage();
+    test_uimage();
+    test_ucolor();
     return 0;
 }
 

--- a/Lux/src/ucolor.hpp
+++ b/Lux/src/ucolor.hpp
@@ -1,0 +1,42 @@
+// Color using unsigned char and bit shifting
+// Intended for use with Cellular Automata in Lux Vitae but can be used for other purposes
+
+typedef unsigned int ucolor;
+
+float rf( const ucolor &c );
+float gf( const ucolor &c );
+float bf( const ucolor &c );
+
+// returns single bytes per component - assumes [0.0, 1.0] range
+// clip or constrain out of range values before using
+unsigned char rc( const ucolor &c );
+unsigned char gc( const ucolor &c );
+unsigned char bc( const ucolor &c );
+
+// set component
+void setrf( ucolor &c, const float& r );
+void setgf( ucolor &c, const float& g );
+void setbf( ucolor &c, const float& b );
+void setf(  ucolor &c, const float& r, const float& g, const float& b );
+ucolor usetf(          const float& r, const float& g, const float& b );
+// TODO - set from bracketed list
+
+void setrc( ucolor &c, const unsigned char& r );
+void setgc( ucolor &c, const unsigned char& g );
+void setbc( ucolor &c, const unsigned char& b );
+void setc(  ucolor &c, const unsigned char& r, const unsigned char& g, const unsigned char& b );
+ucolor usetc(          const unsigned char& r, const unsigned char& g, const unsigned char& b );
+
+ucolor shift_right_1( const ucolor &c );
+ucolor shift_right_2( const ucolor &c );
+ucolor shift_right_3( const ucolor &c );
+ucolor shift_right_4( const ucolor &c );
+ucolor shift_right_5( const ucolor &c );
+ucolor shift_right_6( const ucolor &c );
+ucolor shift_right_7( const ucolor &c );
+
+ucolor blend( const ucolor& a,const ucolor& b );
+
+unsigned long luminance( const ucolor& in );
+
+ucolor gray( const ucolor& in );

--- a/Lux/src/uimage.cpp
+++ b/Lux/src/uimage.cpp
@@ -1,0 +1,68 @@
+#include "uimage.hpp"
+#include <memory>
+#include "image_loader.hpp"
+
+// pixel modification functions
+void uimage :: grayscale() {
+    std :: transform( base.begin(), base.end(), base.begin(), []( ucolor &f ) { return gray( f ); } );
+}
+
+void uimage :: load( const std :: string& filename ) {
+    reset();
+    image_loader loader( filename );
+    set_dim( { loader.xsiz, loader.ysiz } );
+
+	int c = 0;
+    ucolor f;
+
+    for (auto it = begin (loader.img); it <= end (loader.img); ) {
+        if( loader.channels == 1 )	// monochrome image
+        {
+            setrc( f, *it );
+            setgc( f, *it );
+            setbc( f, *it );
+            it++;
+        }
+
+        if( loader.channels == 2 ) // don't know what to do in this case
+        {
+            setrc( f, *it );
+            setgc( f, *it );
+            setbc( f, *it );
+            it++; it++;
+        }
+
+        if( ( loader.channels == 3 ) | ( loader.channels == 4 ) )
+        {
+            setrc( f, *it );
+            it++;
+            setgc( f, *it );
+            it++;
+            setbc( f, *it );
+            it++;
+        }
+
+        // skip alpha channel - rgba ... if argb need to move line up
+        if( loader.channels == 4 ) it++;	
+        base.push_back( f );
+    }
+    mip_it();
+}
+
+void uimage :: spool( std :: vector< unsigned char >& img )
+{
+    std :: for_each( base.begin(), base.end(), [ &img ]( const ucolor &f ) {
+        img.push_back( rc( f ) );
+        img.push_back( gc( f ) );
+        img.push_back( bc( f ) ); } );
+}
+
+void uimage :: write_jpg( const std :: string& filename, int quality ) {
+    std :: vector< unsigned char > img;
+	spool( img );
+	wrapped_write_jpg( filename.c_str(), dim.x, dim.y, 3, img.data(), quality );
+}
+
+void uimage :: write_png( const std :: string& filename ) {
+	wrapped_write_png( filename.c_str(), dim.x, dim.y, 4, (unsigned char *)base.data() );
+}

--- a/Lux/src/uimage.hpp
+++ b/Lux/src/uimage.hpp
@@ -1,0 +1,23 @@
+#include "ucolor.hpp"
+#include "image.hpp"
+
+class uimage : public image< ucolor > {
+
+protected:
+    void spool( std :: vector< unsigned char >& img );
+
+public:
+    uimage() : image() {}     
+    // creates image of particular size 
+    uimage( const vec2i& dims ) : image( dims ){}     
+    uimage( const vec2i& dims, const bb2f& bb ) : image( dims, bb ) {}     
+    // copy constructor
+    uimage( const I& img ) : image( img ) {}     
+    // pixel modification functions
+    void grayscale();
+
+    // I/O functions
+    void load(      const std :: string& filename );
+    void write_jpg( const std :: string& filename, int quality );
+    void write_png( const std :: string& filename );
+};


### PR DESCRIPTION
Add 32 bit color and image - this will be used for cellular automata. Uses fast operations such as bit shifting and bitwise masking.

Add PNG file support.

Use math functions such as `floor()` rather than floating point specific operations such as `floorf()`. In C++ 11, these operations are overloaded to accept floating-point parameters without performance penalty. Fixes a portability bug.

Allow comparisons between images of any type using a nested template.