### PR TITLE
Add imagesplat

### DIFF
--- a/Lux/src/image.hpp
+++ b/Lux/src/image.hpp
@@ -108,6 +108,7 @@ public:
         const vec2f& center, 			// coordinates of splat center
         const float& scale, 			// radius of splat
         const float& theta, 			// rotation in degrees
+        const bool& tint_me,            // multiply by tint value?
         const T& tint,				    // change the color of splat
         const I& g 	);		            // image of the splat
 

--- a/Lux/src/vect2.hpp
+++ b/Lux/src/vect2.hpp
@@ -58,9 +58,14 @@ template< class T, int M > struct bounding_box {
     V minp, maxp;  // Padded bounding box values to calculate if point is within a specified distance to bounding box in any dimension
 
     bounding_box()                           : 
-        b1( { -1.0f, -1.0f } ), b2( { 1.0f, 1.0f } ), minv( b1 ), maxv( b2 ), minp( b1 ), maxp( b2 )       { }    
+        b1( { -1.0f, 1.0f } ), b2( { 1.0f, -1.0f } ), minv( b1 ), maxv( b2 ), minp( b1 ), maxp( b2 )       { }  
+
     bounding_box( const V& v1, const V& v2 ) : 
-        b1( v1 ), b2(v2), minv( min( v1, v2 ) ), maxv( max( v1, v2 ) ), minp( minv ), maxp( maxv ) { }
+        b1( v1 ), b2( v2 ), minv( min( v1, v2 ) ), maxv( max( v1, v2 ) ), minp( minv ), maxp( maxv ) { }
+
+    bounding_box( const V& v, const T& size ) :
+        b1( v - size ), b2( v + size ), minv( min( b1, b2 ) ), maxv( max( b1, b2 ) ), minp( minv ), maxp( maxv ) { }
+           
     // copy+conversion constructor
     template< class U > bounding_box( const bounding_box< U, M >& bbc ) :
         b1( bbc.b1 ), b2( bbc.b2 ), minv( min( b1, b2 ) ), maxv( max( b1, b2 ) ), minp( minv ), maxp( maxv ) { }

--- a/lux.cpp
+++ b/lux.cpp
@@ -193,13 +193,56 @@ void test_vector_field() {
     b.write_jpg( "hk_warp10.jpg", 100 );
 }
 
+void test_splat() {
+    fimage a;
+    a.load( "../../Jen-C/hk_square.jpg" ); 
+    a *= 0.5f;
+    fimage splat;
+    splat.load( "../../Jen-C/orb.jpg" ); 
+   
+    a.splat( 
+        { 0.0f, 0.0f }, 			    // coordinates of splat center
+        0.3f, 			                // radius of splat
+        0.0f, 			                // rotation in degrees
+        false,                          // multiply by tint value?
+        { 1.0f, 0.5f, 0.0f },		    // change the color of splat
+        splat 	);	                    // image of the splat  
+
+    a.splat( 
+        { 0.3, 0.4f }, 			        // coordinates of splat center
+        0.2f, 			                // radius of splat
+        60.0f, 			                // rotation in degrees
+        true,                          // multiply by tint value?
+        { 0.5f, 0.5f, 0.5f },		    // change the color of splat
+        splat 	);	                    // image of the splat  
+
+    a.splat( 
+        { 0.4, 0.3f }, 			        // coordinates of splat center
+        0.2f, 			                // radius of splat
+        -30.0f, 			                // rotation in degrees
+        true,                          // multiply by tint value?
+        { 0.0f, 0.5f, 0.5f },		    // change the color of splat
+        splat 	);	                    // image of the splat  
+
+    a.splat( 
+        { 1.0f, -1.0f }, 			    // coordinates of splat center
+        0.8f, 			                // radius of splat
+        180.0f, 			            // rotation in degrees
+        true,                           // multiply by tint value?
+        { 1.0f, 0.5f, 0.0f },		    // change the color of splat
+        splat 	);	                    // image of the splat
+
+    a.write_jpg( "hk_splat.jpg", 100 );
+}
+
 int main() {
     /* test_frgb();
     test_vect2();
     test_fimage();
     test_uimage();
-    test_ucolor(); */
-    test_vector_field();
+    test_ucolor(); 
+    test_vector_field(); */
+    test_splat();
     return 0;
 }
 


### PR DESCRIPTION
Composite images together - "splat" image must be within a unit circle. Can be tinted a given color, translated, and scaled. 
`imgae::splat()` lives within root class, so fimage, uimage, vector fields, and pointer fields can all be splatted.