### PR TITLE
Add widget switch

### DIFF
--- a/Lux/lux_react/src/components/WidgetGroup.js
+++ b/Lux/lux_react/src/components/WidgetGroup.js
@@ -11,11 +11,11 @@ function WidgetGroup({ panelSize, json }) {
       let widgetComponent;
       let height = 60;
   
-      switch ( widget. type ) {
+      switch ( widget.type ) {
         case 'menu_int':
         case 'menu_string':
           widgetComponent = <JenMenu key = { widget.name } json = { widget } />;
-          break;
+        break;
         case 'slider_int':
         case 'slider_float':
         case 'range_slider_int':
@@ -27,7 +27,7 @@ function WidgetGroup({ panelSize, json }) {
               </Typography>
               <JenSlider key = { widget.name } json = { widget } width = { panelSize - 75 } />
             </Stack>;
-          break;
+        break;
         case 'switch_fn':
         case 'switch_condition':
           height = 30;
@@ -35,22 +35,32 @@ function WidgetGroup({ panelSize, json }) {
             <Stack spacing={1} direction="row" alignItems="center" sx={{ width: '100%', paddingLeft: '0px' }}>
               <JenSwitch key={widget.name} json={widget} size = { "small" } />
               <Typography variant="subtitle1" component="div">
-                  {widget.label}
+                {widget.label}
               </Typography>
             </Stack>;
-          break;
-          /*
-          case 'widget_switch':
-            // make height depend on switch state?
-            widgetComponent =       
-            <Stack spacing={-0.5} direction="column" alignItems="center">
-              <Typography style={{ textAlign: 'center' }}>
-                  {widget.label}
-              </Typography>
-              <JenSlider key = { widget.name } json = { widget } width = { panelSize - 75 } />
-            </Stack>;
-          break;
-          */
+        break;
+        case 'widget_switch':
+          switch( widget.widget.type ) {
+            case 'slider_int':
+            case 'slider_float':
+            case 'range_slider_int':
+            case 'range_slider_float':   
+              widgetComponent =       
+                <Stack spacing={-0.5} direction="column" alignItems="center">
+                  <Stack spacing={1} direction="row" alignItems="center" sx={{ width: '100%', paddingLeft: '0px' }}>
+                    <JenSwitch key={widget.switcher.name} json={widget.switcher} size = { "small" } />
+                    <Typography variant="subtitle1" component="div">
+                      {widget.label}
+                    </Typography>
+                  </Stack>
+                  <JenSlider key = { widget.widget.name } json = { widget.widget } width = { panelSize - 75 } />
+                </Stack>;
+            break;
+            default:
+              widgetComponent = <div key={ widget.widget.name }>Unknown widget type: { widget.widget.type }</div>;
+            break;
+          }
+        break;
         default:
           widgetComponent = <div key={ widget.name }>Unknown widget type: { widget.type }</div>;
           break;

--- a/Lux/nebula_files/test_widgets.json
+++ b/Lux/nebula_files/test_widgets.json
@@ -31,23 +31,32 @@
                 "default_value": true
             },
             {
-                "name": "bright_block_switch",
-                "type": "switch_fn",
-                "label": "Brightness block",
-                "description": "Freezes pixels with brightness outide the range",
-                "tool": "switch",
-                "default_value": false
-            },
-            {
-                "name": "bright_block_slider",
-                "type": "range_slider_int",
-                "label": "Brightness block range",
-                "min": 0,
-                "max": 768,
-                "description": "Freezes pixels with brightness outide the range",
-                "tool": "range_slider",
-                "default_value": [ 10, 768 ]
+                "name": "bright_block_widget_switch",
+                "type": "widget_switch",
+                "label": "Brightness freeze",
+                "description": "Freeze pixels with brighness outside the range",
+                "switcher": 
+                {
+                    "name": "bright_block_switch",
+                    "type": "switch_fn",
+                    "label": "Brightness block",
+                    "description": "Freezes pixels with brightness outide the range",
+                    "tool": "switch",
+                    "default_value": false
+                },
+                "widget": 
+                {
+                    "name": "bright_block_slider",
+                    "type": "range_slider_int",
+                    "label": "Brightness block range",
+                    "min": 0,
+                    "max": 768,
+                    "description": "Freezes pixels with brightness outide the range",
+                    "tool": "range_slider",
+                    "default_value": [ 10, 768 ]
+                }
             }
+            
         ]
     }
 ]

--- a/Lux/src/lux_web.cpp
+++ b/Lux/src/lux_web.cpp
@@ -193,6 +193,18 @@ void handle_switch_value( std::string name, bool value ) {
     }
 }
 
+bool get_switch_state( std::string name ) {
+    if( global_context->s->bool_fns.contains( name ) ) {
+        auto& sw = std::get< std::shared_ptr< switch_fn > >(global_context->s->bool_fns[ name ].any_bool_fn);
+        return sw->value;
+    }
+    else if( global_context->s->condition_fns.contains( name ) ) {
+        auto& sw = std::get< std::shared_ptr< switch_condition > >(global_context->s->condition_fns[ name ].my_condition_fn);
+        return sw->value;
+    }
+    return false;
+}
+
 std::string load_file_as_string(const std::string& filePath) {
     std::ifstream fileStream(filePath);
     if (!fileStream) {
@@ -274,6 +286,7 @@ EMSCRIPTEN_BINDINGS(my_module) {
     function( "set_range_slider_value", &set_range_slider_value );
     function( "handle_menu_choice",     &handle_menu_choice );
     function( "handle_switch_value",    &handle_switch_value );
+    function( "get_switch_state",       &get_switch_state);
 
     /*
     function( "get_slider_min",     &get_slider_min);


### PR DESCRIPTION
Combine a widget and switch into a single widget container - used in this case for "brightness block" control of a CA including a switch and range slider. 

The value of the slider is only relevant if the switch is on. Should it be hidden or grayed out when switch is off? Either case will require state to be passed up from the switch component to re-render the widget group.