### PR TITLE
Improve function pointer retrieval

### DIFF
--- a/Lux/src/any_function.hpp
+++ b/Lux/src/any_function.hpp
@@ -4,8 +4,22 @@
 #include <variant>
 #include "next_element.hpp"
 #include "UI.hpp"
+#include "life_hacks.hpp"
 
 template < class T > struct any_fn {};
+
+#define ANY_FN( _T_ ) template<> struct any_fn< _T_ > { \
+    any_##_T_##_fn_ptr any_fn_ptr; \
+    _T_##_fn fn; \
+    std::string name; \
+    _T_ operator () ( _T_& val, element_context& context ) { return fn( val, context ); } \
+    any_fn< _T_ >() : name("identity_" #_T_ "_default") { \
+        std::shared_ptr< identity_##_T_ > f( new identity_fn< _T_ > ); \
+        fn = std::ref( *f ); \
+        any_fn_ptr = f; \
+    } \
+    any_fn< _T_ >( any_##_T_##_fn_ptr any_##_T_##_fn, _T_##_fn fn, std::string name ) : any_fn_ptr( any_##_T_##_fn ), fn( fn ), name( name ) {}; \
+};
 
 typedef std::variant < 
     // harness functions
@@ -27,21 +41,7 @@ typedef std::variant <
 
 > any_float_fn_ptr;
 
-template<> struct any_fn< float > {
-    any_float_fn_ptr any_float_fn;
-    float_fn fn;
-    std::string name;
-
-    float operator () ( float& val, element_context& context ) { return fn( val, context ); }
-
-    any_fn< float>() : name( "identity_float_default" ) { 
-        std::shared_ptr< identity_float > f( new identity_float );
-        fn = std::ref( *f ); 
-        any_float_fn = f; 
-    }
-
-    any_fn< float >( any_float_fn_ptr any_float_fn, float_fn fn, std::string name ) : any_float_fn( any_float_fn ), fn( fn ), name( name ) {}
-};
+ANY_FN( float )
 
 typedef any_fn< float > any_float_fn;
 
@@ -53,24 +53,12 @@ typedef std::variant <
     // ui functions
     std::shared_ptr< slider_int >,
     std::shared_ptr< range_slider_int >,
-    std::shared_ptr< menu_int >
+    std::shared_ptr< menu_int >,
+    std::shared_ptr< multi_direction8_picker >,
+    std::shared_ptr< custom_blur_picker >
 > any_int_fn_ptr;
 
-template<> struct any_fn< int > {
-    any_int_fn_ptr any_int_fn;
-    int_fn fn;
-    std::string name;
-
-    int operator () ( int& val, element_context& context ) { return fn( val, context ); }
-
-    any_fn< int >() : name( "identity_int_default" ) { 
-        std::shared_ptr< identity_int > f( new identity_int );
-        fn = std::ref( *f ); 
-        any_int_fn = f; 
-    }
-
-    any_fn< int >( any_int_fn_ptr any_int_fn, int_fn fn, std::string name ) : any_int_fn( any_int_fn ), fn( fn ), name( name ) {}
-};
+ANY_FN( int )
 
 typedef std::variant <
     // harness functions
@@ -78,21 +66,7 @@ typedef std::variant <
     std::shared_ptr< range_slider_float >
 > any_interval_float_fn_ptr;
 
-template<> struct any_fn< interval_float > {
-    any_interval_float_fn_ptr any_interval_float_fn;
-    interval_float_fn fn;
-    std::string name;
-
-    interval_float operator () ( interval_float& val, element_context& context ) { return fn( val, context ); }
-
-    any_fn< interval_float >() : name( "identity_interval_float_default" ) { 
-        std::shared_ptr< identity_interval_float > f( new identity_interval_float );
-        fn = std::ref( *f ); 
-        any_interval_float_fn = f; 
-    }
-
-    any_fn< interval_float >( any_interval_float_fn_ptr any_interval_float_fn, interval_float_fn fn, std::string name ) : any_interval_float_fn( any_interval_float_fn ), fn( fn ), name( name ) {}
-};
+ANY_FN( interval_float )
 
 typedef std::variant <
     // harness functions
@@ -100,21 +74,7 @@ typedef std::variant <
     std::shared_ptr< range_slider_int >
 > any_interval_int_fn_ptr;
 
-template<> struct any_fn< interval_int > {
-    any_interval_int_fn_ptr any_interval_int_fn;
-    interval_int_fn fn;
-    std::string name;
-
-    interval_int operator () ( interval_int& val, element_context& context ) { return fn( val, context ); }
-
-    any_fn< interval_int >() : name( "identity_interval_int_default" ) { 
-        std::shared_ptr< identity_interval_int > f( new identity_interval_int );
-        fn = std::ref( *f ); 
-        any_interval_int_fn = f; 
-    }
-
-    any_fn< interval_int >( any_interval_int_fn_ptr any_interval_int_fn, interval_int_fn fn, std::string name ) : any_interval_int_fn( any_interval_int_fn ), fn( fn ), name( name ) {}
-};
+ANY_FN( interval_int )
 
 typedef std::variant <
     // harness functions
@@ -124,21 +84,7 @@ typedef std::variant <
     std::shared_ptr< mouse_pos_fn >
 > any_vec2f_fn_ptr;
 
-template<> struct any_fn< vec2f > {
-    any_vec2f_fn_ptr any_vec2f_fn;
-    vec2f_fn fn;
-    std::string name;
-
-    vec2f operator () ( vec2f& val, element_context& context ) { return fn( val, context ); }
-
-    any_fn< vec2f >() : name( "identity_vec2f_default" ) { 
-        std::shared_ptr< identity_vec2f > f( new identity_vec2f );
-        fn = std::ref( *f ); 
-        any_vec2f_fn = f; 
-    }
-
-    any_fn< vec2f >( any_vec2f_fn_ptr any_vec2f_fn, vec2f_fn fn, std::string name ) : any_vec2f_fn( any_vec2f_fn ), fn( fn ), name( name ) {}
-};
+ANY_FN( vec2f )
 
 typedef std::variant <
     // harness functions
@@ -147,21 +93,7 @@ typedef std::variant <
     std::shared_ptr< mouse_pix_fn >
 > any_vec2i_fn_ptr;
 
-template<> struct any_fn< vec2i > {
-    any_vec2i_fn_ptr any_vec2i_fn;
-    vec2i_fn fn;
-    std::string name;
-
-    vec2i operator () ( vec2i& val, element_context& context ) { return fn( val, context ); }
-
-    any_fn< vec2i >() : name( "identity_vec2i_default" ) { 
-        std::shared_ptr< identity_vec2i > f( new identity_vec2i );
-        fn = std::ref( *f ); 
-        any_vec2i_fn = f; 
-    }
-
-    any_fn< vec2i >( any_vec2i_fn_ptr any_vec2i_fn, vec2i_fn fn, std::string name ) : any_vec2i_fn( any_vec2i_fn ), fn( fn ), name( name ) {}
-};
+ANY_FN( vec2i )
 
 typedef std::variant <
     // harness functions
@@ -169,21 +101,7 @@ typedef std::variant <
     std::shared_ptr< adder_frgb >
 > any_frgb_fn_ptr;
 
-template<> struct any_fn< frgb > {
-    any_frgb_fn_ptr any_frgb_fn;
-    frgb_fn fn;
-    std::string name;
-
-    frgb operator () ( frgb& val, element_context& context ) { return fn( val, context ); }
-
-    any_fn< frgb >() : name( "identity_vec2i_default" ) { 
-        std::shared_ptr< identity_frgb > f( new identity_frgb );
-        fn = std::ref( *f ); 
-        any_frgb_fn = f; 
-    }
-
-    any_fn< frgb >( any_frgb_fn_ptr any_frgb_fn, frgb_fn fn, std::string name ) : any_frgb_fn( any_frgb_fn ), fn( fn ), name( name ) {}
-};
+ANY_FN( frgb )
 
 typedef std::variant <
     // harness functions
@@ -191,42 +109,14 @@ typedef std::variant <
     std::shared_ptr< adder_ucolor >
 > any_ucolor_fn_ptr;
 
-template<> struct any_fn< ucolor > {
-    any_ucolor_fn_ptr any_ucolor_fn;
-    ucolor_fn fn;
-    std::string name;
-
-    ucolor operator () ( ucolor& val, element_context& context ) { return fn( val, context ); }
-
-    any_fn< ucolor >() : name( "identity_ucolor_default" ) { 
-        std::shared_ptr< identity_ucolor > f( new identity_ucolor );
-        fn = std::ref( *f ); 
-        any_ucolor_fn = f; 
-    }
-
-    any_fn< ucolor >( any_ucolor_fn_ptr any_ucolor_fn, ucolor_fn fn, std::string name ) : any_ucolor_fn( any_ucolor_fn ), fn( fn ), name( name ) {}
-};
+ANY_FN( ucolor )
 
 typedef std::variant <
     // harness functions
     std::shared_ptr< identity_bb2f >
 > any_bb2f_fn_ptr;
 
-template<> struct any_fn< bb2f > {
-    any_bb2f_fn_ptr any_bb2f_fn;
-    bb2f_fn fn;
-    std::string name;
-
-    bb2f operator () ( bb2f& val, element_context& context ) { return fn( val, context ); }
-
-    any_fn< bb2f >() : name( "identity_bb2f_default" ) { 
-        std::shared_ptr< identity_bb2f > f( new identity_bb2f );
-        fn = std::ref( *f ); 
-        any_bb2f_fn = f; 
-    }
-
-    any_fn< bb2f >( any_bb2f_fn_ptr any_bb2f_fn, bb2f_fn fn, std::string name ) : any_bb2f_fn( any_bb2f_fn ), fn( fn ), name( name ) {}
-};
+ANY_FN( bb2f )
 
 typedef std::variant <
     // harness functions
@@ -236,21 +126,7 @@ typedef std::variant <
     std::shared_ptr< menu_string >
 > any_string_fn_ptr;
 
-template<> struct any_fn< std::string > {
-    any_string_fn_ptr any_string_fn;
-    string_fn fn;
-    std::string name;
-
-    std::string operator () ( std::string& val, element_context& context ) { return fn( val, context ); }
-
-    any_fn< std::string >() : name( "identity_string_default" ) { 
-        std::shared_ptr< identity_string > f( new identity_string );
-        fn = std::ref( *f ); 
-        any_string_fn = f; 
-    }
-
-    any_fn< std::string >( any_string_fn_ptr any_string_fn, string_fn fn, std::string name ) : any_string_fn( any_string_fn ), fn( fn ), name( name ) {}
-};
+ANY_FN( string )
 
 typedef std::variant <
     // harness functions
@@ -260,21 +136,7 @@ typedef std::variant <
     std::shared_ptr< direction_picker_4 >
 > any_direction4_fn_ptr;
 
-template<> struct any_fn< direction4 > {
-    any_direction4_fn_ptr any_direction4_fn;
-    direction4_fn fn;
-    std::string name;
-
-    direction4 operator () ( direction4& val, element_context& context ) { return fn( val, context ); }
-
-    any_fn< direction4 >() : name( "identity_direction4_default" ) { 
-        std::shared_ptr< identity_direction4 > f( new identity_direction4 );
-        fn = std::ref( *f ); 
-        any_direction4_fn = f; 
-    }
-
-    any_fn< direction4 >( any_direction4_fn_ptr any_direction4_fn, direction4_fn fn, std::string name ) : any_direction4_fn( any_direction4_fn ), fn( fn ), name( name ) {}
-};
+ANY_FN( direction4 )
 
 typedef std::variant <
     // harness functions
@@ -284,23 +146,22 @@ typedef std::variant <
     std::shared_ptr< direction_picker_8 >
 > any_direction8_fn_ptr;
 
-template<> struct any_fn< direction8 > {
-    any_direction8_fn_ptr any_direction8_fn;
-    direction8_fn fn;
-    std::string name;
-
-    direction8 operator () ( direction8& val, element_context& context ) { return fn( val, context ); }
-
-    any_fn< direction8 >() : name( "identity_direction8_default" ) { 
-        std::shared_ptr< identity_direction8 > f( new identity_direction8 );
-        fn = std::ref( *f ); 
-        any_direction8_fn = f; 
-    }
-
-    any_fn< direction8 >( any_direction8_fn_ptr any_direction8_fn, direction8_fn fn, std::string name ) : any_direction8_fn( any_direction8_fn ), fn( fn ), name( name ) {}
-};
+ANY_FN( direction8 )
 
 typedef std::variant < 
+    // harness functions
+    std::shared_ptr< identity_box_blur_type >,
+
+    // ui functions
+    std::shared_ptr< box_blur_picker >
+> any_box_blur_type_fn_ptr;
+
+ANY_FN( box_blur_type )
+
+typedef std::variant < 
+    // identity
+    std::shared_ptr< identity_bool >,
+
     // bool harness functions
     std::shared_ptr< initial_element_fn >,
     std::shared_ptr< following_element_fn >,
@@ -329,21 +190,7 @@ typedef std::variant <
     std::shared_ptr< widget_switch_fn >
 > any_bool_fn_ptr;
 
-template<> struct any_fn< bool > {
-    any_bool_fn_ptr any_bool_fn;
-    bool_fn fn;
-    std::string name;
-
-    bool operator () ( bool& val, element_context& context ) { return fn( val, context ); }
-
-    any_fn< bool >() : name( "identity_bool_default" ) { 
-        std::shared_ptr< initial_element_fn > f( new initial_element_fn );
-        fn = std::ref( *f ); 
-        any_bool_fn = f; 
-    }
-
-    any_fn< bool >( any_bool_fn_ptr any_bool_fn, bool_fn fn, std::string name ) : any_bool_fn( any_bool_fn ), fn( fn ), name( name ) {}
-};
+ANY_FN( bool )
 
 typedef std::variant < 
     std::shared_ptr< initial_element_condition >,
@@ -436,6 +283,7 @@ typedef std::variant <
     any_fn< std::string >,
     any_fn< direction4 >,
     any_fn< direction8 >,
+    any_fn< box_blur_type >,
     any_fn< bool >,
     any_condition_fn,
     any_gen_fn          

--- a/Lux/src/joy_rand.hpp
+++ b/Lux/src/joy_rand.hpp
@@ -9,7 +9,8 @@
 static std::random_device rd;    // non-deterministic generator
 static std::mt19937 gen( rd() ); // start random engine
 static std::uniform_real_distribution<float> rand1( 0.0f, 1.0f );
-static std::uniform_int_distribution<unsigned int> fair_coin( 0, 1 ); 
+static std::uniform_int_distribution<unsigned int> fair_coin( 0, 1 );
+static std::uniform_int_distribution<unsigned int> rand_uint( 0, 0xffffffff ); 
 static float rand_range( const float a, const float b ) { return a + ( b - a ) * rand1( gen ); }
 
 // potentially unfair coin - returns 1 with probability a
@@ -49,5 +50,8 @@ template< Scalar T > struct interval {
 
 typedef interval< float > interval_float;
 typedef interval< int >   interval_int;
+
+// String typedef for convenience and macros
+typedef std::string string;
 
 #endif // __JOY_RAND_HPP

--- a/Lux/src/lux_web.cpp
+++ b/Lux/src/lux_web.cpp
@@ -176,12 +176,16 @@ void set_slider_value( std::string name, float value ) {
     if( global_context->s->functions.contains( name ) ) {
         any_function& fn = global_context->s->functions[ name ];
         if( std::holds_alternative< any_fn< float > >( fn ) ) {
-            std::get< std::shared_ptr< slider_float > >( std::get< any_fn< float > >( fn ).any_float_fn)->value = value;
+            global_context->s->get_fn_ptr< float, slider_float >( name )->value = value;
+            return;
         }
         else if( std::holds_alternative< any_fn< int > >( fn ) ) {
-            std::get< std::shared_ptr< slider_int > >( std::get< any_fn< int > >( fn ).any_int_fn)->value = (int)std::roundf( value );
+           global_context->s->get_fn_ptr< int, slider_int >( name )->value = (int)std::roundf( value );
+           return;
         }
+        throw std::runtime_error( "slider " + name + " invalid type " );
     }
+    throw std::runtime_error( "slider " + name + " not found in scene" );
 }
 
 void set_range_slider_value( std::string name, float value_min, float value_max ) {
@@ -189,13 +193,17 @@ void set_range_slider_value( std::string name, float value_min, float value_max 
     if( global_context->s->functions.contains( name ) ) { 
         any_function& fn = global_context->s->functions[ name ];
         if( std::holds_alternative< any_fn< interval_float > >( fn ) ) {
-            std::get< std::shared_ptr< range_slider_float > >( std::get< any_fn< interval_float > >( fn ).any_interval_float_fn)->value = interval_float( value_min, value_max );
+            global_context->s->get_fn_ptr< interval_float, range_slider_float >( name )->value = interval_float( value_min, value_max );
+            return;
         }
         else if( std::holds_alternative< any_fn< interval_int > >( fn ) ) {
             //std::cout << "range_slider_int: " << name << " " << value_min << " " << value_max << std::endl;
-            std::get< std::shared_ptr< range_slider_int > >( std::get< any_fn< interval_int > >( fn ).any_interval_int_fn)->value = interval_int( (int)std::roundf( value_min ), (int)std::roundf( value_max ) );
+            global_context->s->get_fn_ptr< interval_int, range_slider_int >( name )->value = interval_int( (int)std::roundf( value_min ), (int)std::roundf( value_max ) );
+            return;
         }
+        throw std::runtime_error( "range slider " + name + " invalid type " );
     }
+    throw std::runtime_error( "range slider " + name + " not found in scene" );
 }
 
 void handle_menu_choice( std::string name, int choice ) {
@@ -203,77 +211,61 @@ void handle_menu_choice( std::string name, int choice ) {
         any_function& fn = global_context->s->functions[ name ];
         if( std::holds_alternative< any_fn< int > >( fn ) ) {
             //std::cout << "handle_menu_choice (menu_int): " << name << " " << choice << std::endl;
-            auto& menu = std::get< std::shared_ptr< menu_int > >( std::get< any_fn< int > >( fn ).any_int_fn );
+            auto menu = global_context->s->get_fn_ptr< int, menu_int >( name );
             menu->choose( choice );
+            // future: allow menu to reset a single buffer
             if( menu->rerender ) restart();
+            return;
         }
         else if( std::holds_alternative< any_fn< std::string > >( fn ) ) {
             //std::cout << "handle_menu_choice (menu_string): " << name << " " << choice << std::endl;
-            auto& menu = std::get< std::shared_ptr< menu_string > >( std::get< any_fn< std::string > >( fn ).any_string_fn );
+            auto menu = global_context->s->get_fn_ptr< std::string, menu_string >( name );
             menu->choose( choice );
+            // future: allow menu to reset a single buffer
             if( menu->rerender ) restart();
+            return;
         }
+        throw std::runtime_error( "menu " + name + " invalid type " );
     }
+    throw std::runtime_error( "menu " + name + " not found in scene" );
 }
 
 void handle_switch_value( std::string name, bool value ) {
     if( global_context->s->functions.contains( name ) ) {
         any_function& fn = global_context->s->functions[ name ];
         if( std::holds_alternative< any_fn< bool > >( fn ) ) {
-            auto& sw = std::get< std::shared_ptr< switch_fn > >( std::get< any_fn< bool > >( fn ).any_bool_fn );
+            auto sw = global_context->s->get_fn_ptr< bool, switch_fn >( name );
             sw->value = value;
+            return;
         } 
         else if( std::holds_alternative< any_condition_fn >( fn ) ) {
             auto& sw = std::get< std::shared_ptr< switch_condition > >( std::get< any_condition_fn >( fn ).my_condition_fn );
             sw->value = value;
+            return;
         }
+        throw std::runtime_error( "switch " + name + " invalid type " );
     }
+    throw std::runtime_error( "switch " + name + " not found in scene" );
 }
 
 void pick_direction8( std::string name, int value ) {
-    if( global_context->s->functions.contains( name ) ) {
-        any_function& fn = global_context->s->functions[ name ];
-        if( std::holds_alternative< any_fn< direction8 > >( fn ) ) {
-            auto& picker = std::get< std::shared_ptr< direction_picker_8 > >(std::get< any_fn< direction8 > >( fn ).any_direction8_fn);
-            picker->value = (direction8)value;
-        }
-    }
+    auto picker = global_context->s->get_fn_ptr< direction8, direction_picker_8 >( name );
+    picker->value = ( direction8 )value;
 }
 
 void pick_direction4( std::string name, int value ) {
-    if( global_context->s->functions.contains( name ) ) {
-        any_function& fn = global_context->s->functions[ name ];
-        if( std::holds_alternative< any_fn< direction4 > >( fn ) ) {
-            auto& picker = std::get< std::shared_ptr< direction_picker_4 > >( std::get< any_fn< direction4 > >( fn ).any_direction4_fn);
-            picker->value = (direction4)value;
-        }
-    }
+    auto picker = global_context->s->get_fn_ptr< direction4, direction_picker_4 >( name );
+    picker->value = ( direction4 )value;
 }
 
 void pick_blur_method( std::string name, int value ) {
-    if( global_context->s->functions.contains( name ) ) {
-        any_function& fn = global_context->s->functions[ name ];
-        if( std::holds_alternative< any_fn< box_blur_type > >( fn ) ) {
-            auto& picker = std::get< std::shared_ptr< box_blur_picker > >( std::get< any_fn< box_blur_type > >( fn ).any_box_blur_type_fn);
-            picker->value = (box_blur_type)value;
-        }
-    }
+    auto picker = global_context->s->get_fn_ptr< box_blur_type, box_blur_picker >( name );
+    picker->value = (box_blur_type)value;
 }
 
 void pick_multi_direction8( std::string name, int value, int id ) {
-    if( global_context->s->functions.contains( name ) ) {
-        any_function& fn = global_context->s->functions[ name ];
-        /* Need to do a std::visit for a standalone multi direction picker
-        if( std::holds_alternative< any_fn< int > >( fn ) ) {
-            auto& picker = std::get< std::shared_ptr< multi_direction8_picker > >( std::get< any_fn< int > >( fn ).any_int_fn );
-            picker->value = value;
-        }
-        */
-        if( std::holds_alternative< any_fn< int > >( fn ) ) {
-            auto& picker = std::get< std::shared_ptr< custom_blur_picker > >( std::get< any_fn< int > >( fn ).any_int_fn );
-            picker->set_picker_value( value, id );
-        }
-    }
+    auto picker = global_context->s->get_fn_ptr< int, custom_blur_picker >( name );
+    picker->set_picker_value( value, id );
 }
 
 void print_vector_of_pairs( std::vector< std::pair< int, int > > pickers ) {
@@ -283,27 +275,17 @@ void print_vector_of_pairs( std::vector< std::pair< int, int > > pickers ) {
 }
 
 void remove_custom_blur_pickers( std::string name, int index ) {
-    std::cout << "remove_custom_blur_pickers: " << name << " " << index << std::endl;
-    if( global_context->s->functions.contains( name ) ) {
-        any_function& fn = global_context->s->functions[ name ];
-        if( std::holds_alternative< any_fn< int > >( fn ) ) {
-            auto& picker = std::get< std::shared_ptr< custom_blur_picker > >( std::get< any_fn< int > >( fn ).any_int_fn );
-            picker->remove_pickers( index );
-            print_vector_of_pairs( picker->pickers );
-        }
-    }
+    //std::cout << "remove_custom_blur_pickers: " << name << " " << index << std::endl;
+    auto picker = global_context->s->get_fn_ptr< int, custom_blur_picker >( name );
+    picker->remove_pickers( index );
+    //print_vector_of_pairs( picker->pickers );
 }
 
 void add_custom_blur_pickers( std::string name ) {
-    std::cout << "add_custom_blur_pickers: " << name << std::endl;
-    if( global_context->s->functions.contains( name ) ) {
-        any_function& fn = global_context->s->functions[ name ];
-        if( std::holds_alternative< any_fn< int > >( fn ) ) {
-            auto& picker = std::get< std::shared_ptr< custom_blur_picker > >( std::get< any_fn< int > >( fn ).any_int_fn );
-            picker->add_pickers();
-            print_vector_of_pairs( picker->pickers );
-        }
-    }
+    //std::cout << "add_custom_blur_pickers: " << name << std::endl;
+    auto picker = global_context->s->get_fn_ptr< int, custom_blur_picker >( name );
+    picker->add_pickers();
+    //print_vector_of_pairs( picker->pickers );
 }
 
 /*

--- a/Lux/src/scene.hpp
+++ b/Lux/src/scene.hpp
@@ -210,39 +210,41 @@ struct scene {
     std::unordered_map< std::string, any_effect_fn > effects;
 
     std::unordered_map< std::string, any_buffer_pair_ptr > buffers; // Source images and results of effect stacks
-    std::vector< effect_list > queue; // list of buffers rendered in order 
+    std::vector< effect_list > queue; // list of buffers rendered in order of execution
 
     float time; 
     float time_interval; 
     float default_time_interval;
-    bool paused;
+    
     float aspect;   // aspect ratio of output buffer
         
     scene( float time_interval_init = 1.0f );                                // create empty scene object
     scene( const std::string& filename, float time_interval_init = 1.0f );   // Load scene file (JSON) into new scene object
 
-/*
-    template< class T, class F > std::shared_ptr< F > get_fn_ptr( const std::string& name ) noexcept {
-        if( functions.contains( name ) ) {
-            auto fn = std::get_if< any_fn< T >* >( &( functions[ name ] ) );
-            if( fn != nullptr ) {
-                auto fn_ptr = std::get_if< std::shared_ptr< F >* >( &( fn->any_fn ) );
-                if( fn_ptr != nullptr ) {
-                    return *fn_ptr;
-                }
-                else {
-                    return nullptr;
-                }
-            }
-            else {
-                return nullptr;
-            }
-        }
-        else {
+
+    template< class T, class F > std::shared_ptr< F > get_fn_ptr( const std::string& name ) {
+        if( !functions.contains( name ) ) {
+            throw std::runtime_error( "function " + name + " not found in scene" ); 
             return nullptr;
         }
+        else {
+            if( !std::holds_alternative< any_fn< T > >( functions[ name ] ) ) {
+                throw std::runtime_error( "function " + name + " not of return type " + typeid( T ).name() );
+                return nullptr;
+            }
+            else {
+                auto fn = std::get< any_fn< T > >( functions[ name ] );
+                if( !std::holds_alternative< std::shared_ptr< F > >( fn.any_fn_ptr ) ) {
+                    throw std::runtime_error( "function " + name + " not of type " + typeid( F ).name() );
+                    return nullptr;
+                }
+                else {
+                    return std::get< std::shared_ptr< F > >( fn.any_fn_ptr );
+                }
+            }
+        }
     }
-*/
+
     // Get mouse position in parametric space of output buffer
     vec2f get_mouse_pos() const;
 

--- a/Lux/src/scene_io.cpp
+++ b/Lux/src/scene_io.cpp
@@ -982,7 +982,7 @@ void to_json( nlohmann::json& j, const any_function& af ) {
                         // Other placeholder fields...
                     };
                 }
-            }, wrapper.any_bool_fn);
+            }, wrapper.any_fn_ptr);
         },
         [&]( const any_fn< int >& wrapper ) {
             std::visit(overloaded{
@@ -1040,7 +1040,7 @@ void to_json( nlohmann::json& j, const any_function& af ) {
                         // Other placeholder fields...
                     };
                 }
-            }, wrapper.any_int_fn);
+            }, wrapper.any_fn_ptr);
         },
         [&]( const any_fn< float >& wrapper ) {
             std::visit(overloaded{
@@ -1065,7 +1065,7 @@ void to_json( nlohmann::json& j, const any_function& af ) {
                         // Other placeholder fields...
                     };
                 }
-            }, wrapper.any_float_fn);
+            }, wrapper.any_fn_ptr);
         },
         [&]( const any_fn< interval_int >& wrapper ) {
             std::visit(overloaded{
@@ -1090,7 +1090,7 @@ void to_json( nlohmann::json& j, const any_function& af ) {
                         // Other placeholder fields...
                     };
                 }
-            }, wrapper.any_interval_int_fn);
+            }, wrapper.any_fn_ptr);
         },
         [&]( const any_fn< interval_float >& wrapper ) {
             std::visit( overloaded {
@@ -1115,7 +1115,7 @@ void to_json( nlohmann::json& j, const any_function& af ) {
                         // Other placeholder fields...
                     };
                 }
-            }, wrapper.any_interval_float_fn );
+            }, wrapper.any_fn_ptr );
         },
         /*
         [&]( const any_fn< vec2f >& wrapper ) {
@@ -1152,7 +1152,7 @@ void to_json( nlohmann::json& j, const any_function& af ) {
                         // Other placeholder fields...
                     };
                 },
-            }, wrapper.any_string_fn);  
+            }, wrapper.any_fn_ptr);  
         },
         [&]( const any_fn< direction4 >& wrapper ) {
             std::visit( overloaded {
@@ -1174,7 +1174,7 @@ void to_json( nlohmann::json& j, const any_function& af ) {
                         // Other placeholder fields...
                     };
                 }
-            }, wrapper.any_direction4_fn);
+            }, wrapper.any_fn_ptr);
         },
         [&]( const any_fn< direction8 >& wrapper ) {
             std::visit( overloaded {
@@ -1196,7 +1196,7 @@ void to_json( nlohmann::json& j, const any_function& af ) {
                         // Other placeholder fields...
                     };
                 }
-            }, wrapper.any_direction8_fn );
+            }, wrapper.any_fn_ptr );
         },
         [&]( const any_fn< box_blur_type >& wrapper ) {
             std::visit( overloaded {
@@ -1218,7 +1218,7 @@ void to_json( nlohmann::json& j, const any_function& af ) {
                         // Other placeholder fields...
                     };
                 }
-            }, wrapper.any_box_blur_type_fn );
+            }, wrapper.any_fn_ptr );
         },
         /* 
         [&]( const any_gen_fn& wrapper ) {

--- a/Lux/src/ucolor.cpp
+++ b/Lux/src/ucolor.cpp
@@ -14,9 +14,9 @@ float bf( const ucolor &c )       { return glut.SRGB_to_linear( bc( c ) ); }
 
 // returns single bytes per component 
 unsigned char ac( const ucolor &c ) {  return (unsigned char) ( ( c >> 24 ) & 0xff ); }
-unsigned char rc( const ucolor &c ) {  return (unsigned char) ( ( c       ) & 0xff ); }
+unsigned char rc( const ucolor &c ) {  return (unsigned char) ( ( c >> 16 ) & 0xff ); }
 unsigned char gc( const ucolor &c ) {  return (unsigned char) ( ( c >>  8 ) & 0xff ); }
-unsigned char bc( const ucolor &c ) {  return (unsigned char) ( ( c >> 16 ) & 0xff ); }
+unsigned char bc( const ucolor &c ) {  return (unsigned char) ( ( c       ) & 0xff ); }
 
 // set component
 void setaf( ucolor &c, const float& a )   { setac( c, ( unsigned char )( std::clamp( a, 0.0f, 1.0f ) * 255.0f ) ); }


### PR DESCRIPTION
Scene file error will throw exemption rather than causing segfault. Change function wrapper classes, use macro for template specialization.

Refactor code to retrieve function pointer by adding function to scene class:

```
    template< class T, class F > std::shared_ptr< F > get_fn_ptr( const std::string& name ) {
        if( !functions.contains( name ) ) {
            throw std::runtime_error( "function " + name + " not found in scene" ); 
            return nullptr;
        }
        else {
            if( !std::holds_alternative< any_fn< T > >( functions[ name ] ) ) {
                throw std::runtime_error( "function " + name + " not of return type " + typeid( T ).name() );
                return nullptr;
            }
            else {
                auto fn = std::get< any_fn< T > >( functions[ name ] );
                if( !std::holds_alternative< std::shared_ptr< F > >( fn.any_fn_ptr ) ) {
                    throw std::runtime_error( "function " + name + " not of type " + typeid( F ).name() );
                    return nullptr;
                }
                else {
                    return std::get< std::shared_ptr< F > >( fn.any_fn_ptr );
                }
            }
        }
    }
```