### PR TITLE
Improve Dockerfile permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM emscripten/emsdk
 
-RUN apt update -y && apt install -y clang-12 vim tmux
+RUN apt update -y && apt install -y clang-12 vim tmux sudo
 
 RUN update-alternatives --install /usr/bin/cc cc /usr/bin/clang-12 100 \
     && update-alternatives --install /usr/bin/cpp ccp /usr/bin/clang++-12 100 \

--- a/rund
+++ b/rund
@@ -1,2 +1,7 @@
 #!/usr/bin/bash
-exec docker run --rm -it -v $(pwd):$(pwd) --net=host jentest bash
+export DUSERNAME=$(id -u -n)
+export DGROUP=$(id -g -n)
+export DUID=$(id -u)
+export DGID=$(id -g)
+
+exec docker run -e DGROUP -e DUSERNAME -e DUID -e DGID -w $(pwd) --rm -it -v $(pwd):$(pwd) --net=host jentest ./scripts/second-stage.sh

--- a/scripts/second-stage.sh
+++ b/scripts/second-stage.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/bash
+
+addgroup --gid $DGID $DGROUP --quiet
+adduser --gecos GECOS --uid $DUID --gid $DGID $DUSERNAME --disabled-password --quiet --no-create-home
+usermod -a -G sudo $DUSERNAME
+cat >/etc/sudoers <<EOF
+#
+# This file MUST be edited with the 'visudo' command as root.
+#
+# Please consider adding local content in /etc/sudoers.d/ instead of
+# directly modifying this file.
+#
+# See the man page for details on how to write a sudoers file.
+#
+Defaults	env_reset
+Defaults	mail_badpass
+Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"
+Defaults	use_pty
+
+# This preserves proxy settings from user environments of root
+# equivalent users (group sudo)
+#Defaults:%sudo env_keep += "http_proxy https_proxy ftp_proxy all_proxy no_proxy"
+
+# This allows running arbitrary commands, but so does ALL, and it means
+# different sudoers have their choice of editor respected.
+#Defaults:%sudo env_keep += "EDITOR"
+
+# Completely harmless preservation of a user preference.
+#Defaults:%sudo env_keep += "GREP_COLOR"
+
+# While you shouldn't normally run git as root, you need to with etckeeper
+#Defaults:%sudo env_keep += "GIT_AUTHOR_* GIT_COMMITTER_*"
+
+# Per-user preferences; root won't have sensible values for them.
+#Defaults:%sudo env_keep += "EMAIL DEBEMAIL DEBFULLNAME"
+
+# "sudo scp" or "sudo rsync" should be able to use your SSH agent.
+#Defaults:%sudo env_keep += "SSH_AGENT_PID SSH_AUTH_SOCK"
+
+# Ditto for GPG agent
+#Defaults:%sudo env_keep += "GPG_AGENT_INFO"
+
+# Host alias specification
+
+# User alias specification
+
+# Cmnd alias specification
+
+# User privilege specification
+root	ALL=(ALL:ALL) ALL
+
+# Members of the admin group may gain root privileges
+%admin ALL=(ALL) ALL
+
+# Allow members of group sudo to execute any command
+%sudo  ALL=(ALL) NOPASSWD: ALL
+
+# See sudoers(5) for more information on "@include" directives:
+
+@includedir /etc/sudoers.d
+EOF
+
+exec su $DUSERNAME -c 'bash -i'


### PR DESCRIPTION
this makes a user with the same uid / gid inside the docker so the homedir outside is not polluted with root-owned files.
it also adds the user to the sudo group and turns off the password prompt within the docker so superuser is still available using sudo when necessary inside the container.